### PR TITLE
bug/OTF-4041: dd support for encrypted access OAuth2 access tokens in OAuth2Util

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -441,7 +441,7 @@ public class OAuth2Util {
     JsonNode node;
     try {
       node = JsonUtil.mapper().readTree(Base64.getUrlDecoder().decode(parts.get(1)));
-    } catch (IOException e) {
+    } catch (IOException | IllegalArgumentException e) {
       return null;
     }
 


### PR DESCRIPTION
- Added IllegalArgumentException to catch block in expiresAtMillis method
- Enables compatibility with BigLake API which uses opaque OAuth2 access tokens
- Maintains backward compatibility with existing JWT-based token systems
- Returns null for non-JWT tokens, allowing expiration fallback to properties

More details in Design document: https://teradata-pe.atlassian.net/wiki/spaces/CLDI/pages/758874177/Teradata+OTF+Integration+with+Google+BigLake+Iceberg+REST+Catalog+InProgress#4.2-BigLake-API-Token-Requirements-(Access-Token-vs-ID-Token-Implementation)
