### PR TITLE
Fix struct fieldid if missing in file schema, read from expected

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -234,7 +234,10 @@ abstract class BaseParquetReaders<T> {
         if (fieldReader != null) {
           Type fieldType = fields.get(i);
           int fieldD = type.getMaxDefinitionLevel(path(fieldType.getName())) - 1;
-          int id = fieldType.getId().intValue();
+          int id =
+              fieldType.getId() != null
+                  ? fieldType.getId().intValue()
+                  : expected.fields().get(i).fieldId();
           readersById.put(id, ParquetValueReaders.option(fieldType, fieldD, fieldReader));
         }
       }


### PR DESCRIPTION
When FileSchema has id null for inner columns of Struct, rely on expected field id.